### PR TITLE
fix(dashboard): do not count policy-blocked spoofing against the pass rate

### DIFF
--- a/internal/storage/common.go
+++ b/internal/storage/common.go
@@ -31,10 +31,14 @@ type Statistics struct {
 	TotalReports      int     `json:"total_reports"`
 	TotalMessages     int     `json:"total_messages"`
 	CompliantMessages int     `json:"compliant_messages"`
-	ComplianceRate    float64 `json:"compliance_rate"`
-	UniqueSourceIPs   int     `json:"unique_source_ips"`
-	UniqueDomains     int     `json:"unique_domains"`
-	HasData           bool    `json:"has_data"`
+	// EnforcedMessages counts non-compliant messages the receiver already
+	// blocked (disposition reject or quarantine) — the published policy
+	// working, not an authentication gap.
+	EnforcedMessages int     `json:"enforced_messages"`
+	ComplianceRate   float64 `json:"compliance_rate"`
+	UniqueSourceIPs  int     `json:"unique_source_ips"`
+	UniqueDomains    int     `json:"unique_domains"`
+	HasData          bool    `json:"has_data"`
 }
 
 type TopSourceIP struct {
@@ -203,6 +207,17 @@ func (s *Storage) GetStatistics() (*Statistics, error) {
 
 	if stats.TotalMessages > 0 {
 		stats.ComplianceRate = float64(stats.CompliantMessages) / float64(stats.TotalMessages) * 100
+	}
+
+	err = s.db.QueryRow(`
+		SELECT COALESCE(SUM(count), 0)
+		FROM records
+		WHERE disposition IN ('reject', 'quarantine')
+		  AND dkim_result != 'pass'
+		  AND spf_result != 'pass'
+	`).Scan(&stats.EnforcedMessages)
+	if err != nil {
+		return nil, fmt.Errorf("query enforced messages: %w", err)
 	}
 
 	err = s.db.QueryRow("SELECT COUNT(DISTINCT source_ip) FROM records").Scan(&stats.UniqueSourceIPs)

--- a/internal/storage/common_test.go
+++ b/internal/storage/common_test.go
@@ -122,5 +122,105 @@ func TestGetStatistics_HasData(t *testing.T) {
 		if stats.ComplianceRate != 100.0 {
 			t.Errorf("Expected ComplianceRate to be 100.0, got %f", stats.ComplianceRate)
 		}
+
+		if stats.EnforcedMessages != 0 {
+			t.Errorf("Expected EnforcedMessages to be 0, got %d", stats.EnforcedMessages)
+		}
+	})
+
+	t.Run("blocked spoofing counts as enforced", func(t *testing.T) {
+		xmlData := `<?xml version="1.0" encoding="UTF-8"?>
+<feedback>
+  <version>1.0</version>
+  <report_metadata>
+    <org_name>google.com</org_name>
+    <email>noreply-dmarc-support@google.com</email>
+    <report_id>12345678901234567891</report_id>
+    <date_range>
+      <begin>1609545600</begin>
+      <end>1609632000</end>
+    </date_range>
+  </report_metadata>
+  <policy_published>
+    <domain>example.com</domain>
+    <adkim>r</adkim>
+    <aspf>r</aspf>
+    <p>reject</p>
+    <sp>reject</sp>
+    <pct>100</pct>
+  </policy_published>
+  <record>
+    <row>
+      <source_ip>198.51.100.7</source_ip>
+      <count>40</count>
+      <policy_evaluated>
+        <disposition>reject</disposition>
+        <dkim>fail</dkim>
+        <spf>fail</spf>
+      </policy_evaluated>
+    </row>
+    <identifiers>
+      <header_from>example.com</header_from>
+    </identifiers>
+    <auth_results>
+      <spf>
+        <domain>example.com</domain>
+        <result>fail</result>
+      </spf>
+    </auth_results>
+  </record>
+  <record>
+    <row>
+      <source_ip>192.0.2.1</source_ip>
+      <count>10</count>
+      <policy_evaluated>
+        <disposition>none</disposition>
+        <dkim>pass</dkim>
+        <spf>pass</spf>
+      </policy_evaluated>
+    </row>
+    <identifiers>
+      <header_from>example.com</header_from>
+    </identifiers>
+    <auth_results>
+      <spf>
+        <domain>example.com</domain>
+        <result>pass</result>
+      </spf>
+      <dkim>
+        <domain>example.com</domain>
+        <result>pass</result>
+      </dkim>
+    </auth_results>
+  </record>
+</feedback>`
+
+		feedback, err := parser.ParseReport([]byte(xmlData))
+		if err != nil {
+			t.Fatalf("Failed to parse report: %v", err)
+		}
+
+		err = storage.SaveReport(feedback)
+		if err != nil {
+			t.Fatalf("Failed to save report: %v", err)
+		}
+
+		stats, err := storage.GetStatistics()
+		if err != nil {
+			t.Fatalf("Failed to get statistics after adding report: %v", err)
+		}
+
+		// 100 from the first subtest + 50 from this report
+		if stats.TotalMessages != 150 {
+			t.Errorf("Expected TotalMessages to be 150, got %d", stats.TotalMessages)
+		}
+
+		if stats.CompliantMessages != 110 {
+			t.Errorf("Expected CompliantMessages to be 110, got %d", stats.CompliantMessages)
+		}
+
+		if stats.EnforcedMessages != 40 {
+			t.Errorf("Expected EnforcedMessages to be 40, got %d", stats.EnforcedMessages)
+		}
 	})
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -88,8 +88,20 @@ const closeDrawer = () => {
 };
 
 // Computed values for hero component
+// Pass rate over delivered mail only. Messages the receiver already blocked
+// (disposition reject/quarantine) are the policy working, not an
+// authentication gap — counting them against the score means more blocked
+// spoofing makes a fully-enforcing domain look less healthy.
 const complianceScore = computed(() => {
-  return statistics.value?.compliance_rate ?? 0;
+  const s = statistics.value;
+  if (!s) return 0;
+  const delivered = (s.total_messages ?? 0) - (s.enforced_messages ?? 0);
+  if (delivered <= 0) return 100;
+  return Math.min(100, ((s.compliant_messages ?? 0) / delivered) * 100);
+});
+
+const enforcedCount = computed(() => {
+  return statistics.value?.enforced_messages ?? 0;
 });
 
 const totalVolume = computed(() => {
@@ -284,6 +296,7 @@ onUnmounted(() => {
             :compliance-score="complianceScore"
             :volume="totalVolume"
             :source-count="sourceCount"
+            :enforced="enforcedCount"
             :has-data="hasData"
             :loading="loading"
             @refresh="refreshData"

--- a/src/components/dashboard/DashboardHero.vue
+++ b/src/components/dashboard/DashboardHero.vue
@@ -5,6 +5,7 @@ const props = defineProps({
   complianceScore: { type: Number, required: true },
   volume: { type: Number, default: 0 },
   sourceCount: { type: Number, default: 0 },
+  enforced: { type: Number, default: 0 },
   hasData: { type: Boolean, default: false },
   dateRange: { type: String, default: "Last 30 Days" },
   loading: { type: Boolean, default: false },
@@ -34,7 +35,11 @@ const statusMessage = computed(() => {
 const statusSubtext = computed(() => {
   if (healthState.value === "nodata")
     return "No DMARC reports received yet. Check IMAP connection.";
-  if (healthState.value === "secure") return "Traffic is fully authenticated.";
+  if (healthState.value === "secure") {
+    return props.enforced > 0
+      ? `Delivered traffic is authenticated. ${fmt(props.enforced)} spoofed messages blocked by your policy.`
+      : "Traffic is fully authenticated.";
+  }
   if (healthState.value === "warning")
     return "Some legitimate email may be failing.";
   return "High risk of spoofing. Immediate action required.";


### PR DESCRIPTION
## Problem

The System Health pass rate divides compliant messages by **all** messages, including mail the receiver already rejected or quarantined because the published policy told it to.

For a domain at `p=reject` this inverts the signal: a wave of botnet spoofing drives the pass rate down and raises the red **"Critical Authentication Gaps / Immediate action required"** banner — the more spoofing the policy successfully blocks, the sicker the domain looks. Real example from one day of Google reports on a `p=reject` domain: 3 legitimate messages, all passing, plus ~90 spoofed messages from ~80 botnet IPs, all rejected. The dashboard showed **59% pass rate, critical**. Nothing was wrong.

## Change

- `Statistics` gains `enforced_messages`: the sum of record counts with disposition `reject` or `quarantine` where neither DKIM nor SPF passed. Computed from the existing `records` table — no schema change.
- The dashboard computes the displayed pass rate over **delivered** mail only: `compliant / (total - enforced)`.
- When the state is healthy and blocked mail exists, the subtext reports it: *"Delivered traffic is authenticated. N spoofed messages blocked by your policy."* — the same data, presented as the policy working rather than as a gap.
- The `compliance_rate` API field is unchanged, so existing consumers (metrics, MCP) keep their semantics.

## Testing

- New storage test: a `p=reject` report with 40 rejected spoofed + 10 delivered passing messages yields `EnforcedMessages == 40`.
- `go test ./internal/storage/ ./internal/parser/` passes; `npm run build` passes.

Related: #89 covered the same banner for the no-data case; this covers the enforcing-domain case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
