### PR TITLE
fix(dashboard): judge health over delivered mail, in the backend

### DIFF
--- a/internal/storage/common.go
+++ b/internal/storage/common.go
@@ -60,9 +60,49 @@ type Statistics struct {
 	TotalMessages     int     `json:"total_messages"`
 	CompliantMessages int     `json:"compliant_messages"`
 	ComplianceRate    float64 `json:"compliance_rate"`
-	UniqueSourceIPs   int     `json:"unique_source_ips"`
-	UniqueDomains     int     `json:"unique_domains"`
-	HasData           bool    `json:"has_data"`
+	// EnforcedMessages counts non-compliant mail the receiver already blocked
+	// (disposition reject or quarantine): the published policy working, not
+	// an authentication gap.
+	EnforcedMessages int `json:"enforced_messages"`
+	// DeliveredComplianceRate is the pass rate over mail that was actually
+	// delivered (total minus enforced). Null when nothing was delivered.
+	DeliveredComplianceRate *float64 `json:"delivered_compliance_rate"`
+	// Health is the backend's verdict for the dashboard: nodata, secure,
+	// warning or critical.
+	Health          string `json:"health"`
+	UniqueSourceIPs int    `json:"unique_source_ips"`
+	UniqueDomains   int    `json:"unique_domains"`
+	HasData         bool   `json:"has_data"`
+}
+
+// Delivered-compliance thresholds (percent) behind Health.
+const (
+	secureRate  = 95
+	warningRate = 80
+)
+
+// classify derives DeliveredComplianceRate and Health from the counts.
+func (st *Statistics) classify() {
+	if !st.HasData {
+		st.Health = "nodata"
+		return
+	}
+	delivered := st.TotalMessages - st.EnforcedMessages
+	if delivered <= 0 {
+		// Everything seen was blocked spoofing: nothing unauthenticated got through.
+		st.Health = "secure"
+		return
+	}
+	rate := float64(st.CompliantMessages) / float64(delivered) * 100
+	st.DeliveredComplianceRate = &rate
+	switch {
+	case rate >= secureRate:
+		st.Health = "secure"
+	case rate >= warningRate:
+		st.Health = "warning"
+	default:
+		st.Health = "critical"
+	}
 }
 
 type TopSourceIP struct {
@@ -230,6 +270,17 @@ func (s *Storage) GetStatistics() (*Statistics, error) {
 		stats.ComplianceRate = float64(stats.CompliantMessages) / float64(stats.TotalMessages) * 100
 	}
 
+	err = s.db.QueryRow(`
+		SELECT COALESCE(SUM(count), 0)
+		FROM records
+		WHERE disposition IN ('reject', 'quarantine')
+		  AND dkim_result != 'pass'
+		  AND spf_result != 'pass'
+	`).Scan(&stats.EnforcedMessages)
+	if err != nil {
+		return nil, fmt.Errorf("query enforced messages: %w", err)
+	}
+
 	err = s.db.QueryRow("SELECT COUNT(DISTINCT source_ip) FROM records").Scan(&stats.UniqueSourceIPs)
 	if err != nil {
 		return nil, fmt.Errorf("query unique source IPs: %w", err)
@@ -240,6 +291,7 @@ func (s *Storage) GetStatistics() (*Statistics, error) {
 		return nil, fmt.Errorf("query unique domains: %w", err)
 	}
 
+	stats.classify()
 	return &stats, nil
 }
 

--- a/internal/storage/common_test.go
+++ b/internal/storage/common_test.go
@@ -233,3 +233,114 @@ func TestGetReports_NullReport(t *testing.T) {
 		}
 	}
 }
+
+// Health is judged over delivered mail only: spoofing the receiver already
+// blocked under the published policy is the policy working, not a gap.
+func TestStatisticsClassify(t *testing.T) {
+	cases := map[string]struct {
+		reports, total, compliant, enforced int
+		wantHealth                          string
+		wantRate                            string // "nil" or the formatted rate
+	}{
+		"no reports":            {0, 0, 0, 0, "nodata", "nil"},
+		"all delivered pass":    {1, 100, 100, 0, "secure", "100.0"},
+		"blocked spoofing only": {1, 90, 0, 90, "secure", "nil"},
+		"3 pass, 90 blocked":    {1, 93, 3, 90, "secure", "100.0"},
+		"warning":               {1, 100, 85, 0, "warning", "85.0"},
+		"critical":              {1, 100, 50, 0, "critical", "50.0"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			st := Statistics{
+				TotalReports: tc.reports, TotalMessages: tc.total,
+				CompliantMessages: tc.compliant, EnforcedMessages: tc.enforced,
+				HasData: tc.reports > 0,
+			}
+			st.classify()
+
+			gotRate := "nil"
+			if st.DeliveredComplianceRate != nil {
+				gotRate = fmt.Sprintf("%.1f", *st.DeliveredComplianceRate)
+			}
+			if st.Health != tc.wantHealth || gotRate != tc.wantRate {
+				t.Fatalf("got health=%q rate=%s, want health=%q rate=%s", st.Health, gotRate, tc.wantHealth, tc.wantRate)
+			}
+		})
+	}
+}
+
+// reportXML builds a one-domain aggregate report from (count, disposition,
+// dkim, spf) rows so tests can synthesise traffic mixes compactly.
+func reportXML(id, policy string, rows ...[4]string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, `<?xml version="1.0"?><feedback><version>1.0</version>
+<report_metadata><org_name>google.com</org_name><report_id>%s</report_id>
+<date_range><begin>1609459200</begin><end>1609545600</end></date_range></report_metadata>
+<policy_published><domain>example.com</domain><p>%s</p><pct>100</pct></policy_published>`, id, policy)
+	for i, r := range rows {
+		fmt.Fprintf(&b, `<record><row><source_ip>192.0.2.%d</source_ip><count>%s</count>
+<policy_evaluated><disposition>%s</disposition><dkim>%s</dkim><spf>%s</spf></policy_evaluated></row>
+<identifiers><header_from>example.com</header_from></identifiers></record>`, i+1, r[0], r[1], r[2], r[3])
+	}
+	b.WriteString("</feedback>")
+	return b.String()
+}
+
+// A p=reject domain that blocks a botnet must read as healthy, and an
+// unenforced domain letting failures through must still drag health down.
+func TestGetStatistics_Health(t *testing.T) {
+	storage, err := NewStorage(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	save := func(xml string) {
+		t.Helper()
+		fb, err := parser.ParseReport([]byte(xml))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := storage.SaveReport(fb); err != nil {
+			t.Fatal(err)
+		}
+	}
+	check := func(wantEnforced int, wantRate float64, wantHealth string) {
+		t.Helper()
+		stats, err := storage.GetStatistics()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stats.EnforcedMessages != wantEnforced || stats.Health != wantHealth ||
+			stats.DeliveredComplianceRate == nil || fmt.Sprintf("%.1f", *stats.DeliveredComplianceRate) != fmt.Sprintf("%.1f", wantRate) {
+			t.Fatalf("got enforced=%d rate=%v health=%q, want enforced=%d rate=%.1f health=%q",
+				stats.EnforcedMessages, stats.DeliveredComplianceRate, stats.Health, wantEnforced, wantRate, wantHealth)
+		}
+	}
+
+	// p=reject: 10 legitimate messages pass, 40 spoofed ones are rejected.
+	save(reportXML("r1", "reject",
+		[4]string{"40", "reject", "fail", "fail"},
+		[4]string{"10", "none", "pass", "pass"},
+	))
+	check(40, 100, "secure")
+
+	// p=none: 50 of 100 fail and are delivered anyway.
+	save(reportXML("r2", "none",
+		[4]string{"50", "none", "fail", "fail"},
+		[4]string{"50", "none", "pass", "pass"},
+	))
+	// delivered = 150 - 40 = 110, compliant = 60
+	check(40, 60.0/110*100, "critical")
+
+	stats, _ := storage.GetStatistics()
+	if stats.ComplianceRate != 40 { // raw rate over all mail is unchanged for metrics
+		t.Errorf("ComplianceRate = %v, want 40", stats.ComplianceRate)
+	}
+	out, _ := json.Marshal(stats)
+	for _, want := range []string{`"enforced_messages":40`, `"health":"critical"`} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("JSON %s\nmissing %s", out, want)
+		}
+	}
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -87,10 +87,15 @@ const closeDrawer = () => {
   }, 300);
 };
 
-// Computed values for hero component
-const complianceScore = computed(() => {
-  return statistics.value?.compliance_rate ?? 0;
-});
+// Computed values for hero component. Health and the pass rate arrive
+// classified from the backend; the hero only renders them.
+const health = computed(() => statistics.value?.health ?? "nodata");
+
+const passRate = computed(
+  () => statistics.value?.delivered_compliance_rate ?? null,
+);
+
+const enforcedCount = computed(() => statistics.value?.enforced_messages ?? 0);
 
 const totalVolume = computed(() => {
   return statistics.value?.total_messages ?? 0;
@@ -98,10 +103,6 @@ const totalVolume = computed(() => {
 
 const sourceCount = computed(() => {
   return statistics.value?.unique_source_ips ?? 0;
-});
-
-const hasData = computed(() => {
-  return statistics.value?.has_data ?? false;
 });
 
 // Helpers
@@ -281,10 +282,11 @@ onUnmounted(() => {
         <!-- Dashboard View -->
         <template v-if="currentView === 'dashboard'">
           <DashboardHero
-            :compliance-score="complianceScore"
+            :health="health"
+            :pass-rate="passRate"
+            :enforced="enforcedCount"
             :volume="totalVolume"
             :source-count="sourceCount"
-            :has-data="hasData"
             :loading="loading"
             @refresh="refreshData"
           />

--- a/src/components/dashboard/DashboardHero.vue
+++ b/src/components/dashboard/DashboardHero.vue
@@ -1,43 +1,49 @@
 <script setup>
 import { computed } from "vue";
 
+// The backend classifies health (nodata, secure, warning, critical) and the
+// pass rate over delivered mail; this component only renders them.
 const props = defineProps({
-  complianceScore: { type: Number, required: true },
+  health: { type: String, default: "nodata" },
+  passRate: { type: Number, default: null },
+  enforced: { type: Number, default: 0 },
   volume: { type: Number, default: 0 },
   sourceCount: { type: Number, default: 0 },
-  hasData: { type: Boolean, default: false },
   dateRange: { type: String, default: "Last 30 Days" },
   loading: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["refresh"]);
 
-// Determine health state based on score and data availability
-const healthState = computed(() => {
-  if (!props.hasData) return "nodata";
-  if (props.complianceScore >= 95) return "secure";
-  if (props.complianceScore >= 80) return "warning";
-  return "critical";
-});
-
 // Format numbers (e.g. 12,450)
 const fmt = (n) => new Intl.NumberFormat("en-US").format(n);
 
-// Dynamic status text
-const statusMessage = computed(() => {
-  if (healthState.value === "nodata") return "Awaiting Data";
-  if (healthState.value === "secure") return "Domain Protected";
-  if (healthState.value === "warning") return "Compliance Issues Detected";
-  return "Critical Authentication Gaps";
-});
+const STATUS_TEXT = {
+  nodata: {
+    message: "Awaiting Data",
+    subtext: "No DMARC reports received yet. Check IMAP connection.",
+  },
+  secure: {
+    message: "Domain Protected",
+    subtext: "Traffic is fully authenticated.",
+  },
+  warning: {
+    message: "Compliance Issues Detected",
+    subtext: "Some legitimate email may be failing.",
+  },
+  critical: {
+    message: "Critical Authentication Gaps",
+    subtext: "High risk of spoofing. Immediate action required.",
+  },
+};
+
+const statusMessage = computed(() => STATUS_TEXT[props.health].message);
 
 const statusSubtext = computed(() => {
-  if (healthState.value === "nodata")
-    return "No DMARC reports received yet. Check IMAP connection.";
-  if (healthState.value === "secure") return "Traffic is fully authenticated.";
-  if (healthState.value === "warning")
-    return "Some legitimate email may be failing.";
-  return "High risk of spoofing. Immediate action required.";
+  if (props.health === "secure" && props.enforced > 0) {
+    return `Delivered traffic is authenticated. ${fmt(props.enforced)} spoofed messages blocked by your policy.`;
+  }
+  return STATUS_TEXT[props.health].subtext;
 });
 </script>
 
@@ -72,11 +78,11 @@ const statusSubtext = computed(() => {
     </header>
 
     <div class="stat-grid">
-      <div class="card health-card" :class="healthState">
+      <div class="card health-card" :class="health">
         <div class="health-content">
           <div class="icon-wrapper">
             <svg
-              v-if="healthState === 'secure'"
+              v-if="health === 'secure'"
               width="24"
               height="24"
               viewBox="0 0 24 24"
@@ -90,7 +96,7 @@ const statusSubtext = computed(() => {
               <path d="m9 12 2 2 4-4" />
             </svg>
             <svg
-              v-else-if="healthState === 'nodata'"
+              v-else-if="health === 'nodata'"
               width="24"
               height="24"
               viewBox="0 0 24 24"
@@ -127,8 +133,8 @@ const statusSubtext = computed(() => {
           </div>
         </div>
 
-        <div class="health-score" v-if="hasData">
-          <span class="score-val">{{ complianceScore.toFixed(1) }}%</span>
+        <div class="health-score" v-if="passRate != null">
+          <span class="score-val">{{ passRate.toFixed(1) }}%</span>
           <span class="score-label">Pass Rate</span>
         </div>
       </div>


### PR DESCRIPTION
## Problem

The System Health card divides compliant messages by **all** messages, including mail the receiver already rejected or quarantined because the published policy told it to. For a `p=reject` domain that inverts the signal: the more spoofing the policy blocks, the sicker the domain looks. @nivr's example in #186: 3 legitimate messages passing plus ~90 spoofed messages rejected showed **59% pass rate, critical**. Nothing was wrong.

The hero also owned the decision: thresholds and the pass-rate math lived in Vue, out of reach of tests.

## Change

Same idea as #186, moved into the backend so the UI only renders a verdict, mirroring how #187 landed for the report list.

- `Statistics` gains three fields, computed in Go from the existing `records` table (no schema change):
  - `enforced_messages`: non-compliant mail with disposition `reject` or `quarantine`.
  - `delivered_compliance_rate`: compliant over delivered (total minus enforced). `null` when nothing was delivered.
  - `health`: `nodata`, `secure` (≥ 95), `warning` (≥ 80) or `critical`. A domain whose traffic was entirely blocked spoofing is `secure`.
- `DashboardHero.vue` receives `health`, `passRate` and `enforced` and maps them to text through a static table. No thresholds remain in the frontend.
- `compliance_rate` is unchanged, so Prometheus metrics and the MCP `get_statistics` tool keep their semantics. The MCP output schema picks up the new fields, with the rate marked nullable.

## Testing

- `TestStatisticsClassify`: six-case table (no data, all delivered pass, blocked spoofing only, 3 pass + 90 blocked, warning, critical).
- `TestGetStatistics_Health`: round trip through SQLite with synthesized reports. A `p=reject` domain with 10 passing and 40 rejected spoofed messages reads `secure` at 100%; adding a `p=none` domain that delivers 50 of 100 failures drops health to `critical` at 54.5%, while the raw `compliance_rate` stays 40.
- End to end: built the binary, seeded a scratch DB with the same synthetic reports, and queried the live API. `/api/statistics` returned `compliance_rate: 20`, `enforced_messages: 40`, `delivered_compliance_rate: 100`, `health: "secure"`.
- `go test ./...`, `go vet`, golangci-lint and `bun run build` pass.

## Follow-up worth deciding

The per-report `status` from #187 still judges the raw rate, so the healthy `p=reject` report above shows **FAIL** at 20% in the list while the hero says Domain Protected. Applying the delivered-rate rule per report would make the two views agree. Left out here to keep this PR to the hero.

Supersedes #186. Thanks @nivr for the diagnosis and the `enforced_messages` definition, both carried over as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
